### PR TITLE
Replaced deprecated app->share function with app->singleton

### DIFF
--- a/ShortcodeServiceProvider.php
+++ b/ShortcodeServiceProvider.php
@@ -18,7 +18,7 @@ class ShortcodeServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app['shortcode'] = $this->app->share(function ($app) {
+        $this->app->singleton('shortcode', function ($app) {
             return new Shortcode();
         });
     }


### PR DESCRIPTION
The app->share function was removed in Laravel 5.4.